### PR TITLE
Umma19 patch issue 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Specmate
-test test
+Just making a dummy pull requst.
 Specmate is a Web-based Modeling and Test-Generation Tool
 
 ## Setup

--- a/bundles/org.json/src/org/json/JSONException.java
+++ b/bundles/org.json/src/org/json/JSONException.java
@@ -1,12 +1,15 @@
 package org.json;
 
+import java.text.ParseException;
+
 /**
  * The JSONException is thrown by the JSON.org classes when things are amiss.
  *
  * @author JSON.org
  * @version 2014-05-03
+ * Updated 2020-10-03 by umma19 to remove run time exception code smell.
  */
-public class JSONException extends RuntimeException {
+public class JSONException extends ParseException {
     private static final long serialVersionUID = 0;
     private Throwable cause;
 
@@ -17,7 +20,7 @@ public class JSONException extends RuntimeException {
      *            Detail about the reason for the exception.
      */
     public JSONException(String message) {
-        super(message);
+        super(message,0);
     }
 
     /**
@@ -25,7 +28,7 @@ public class JSONException extends RuntimeException {
      * @param cause The cause.
      */
     public JSONException(Throwable cause) {
-        super(cause.getMessage());
+        super(cause.getMessage(),0);
         this.cause = cause;
     }
 


### PR DESCRIPTION
All the exceptions inside JSONArray.java are related to parsing string object into json object. Either the text is not in proper format, the formed object is null or the expected object is amiss. Therefore, instead of removing the declaration of thrown exception 'org.json.JSONException' (which is a runtime exception) inside JSONArray class, I have updated the JSONException to extend the ParseException which is inherited from Exception class. 

Updating the JSONArray class to remove this code smell required update in other classes of the org.json package as well. 
 
[Trello Card]()
