### PR TITLE
#37:[CS]: Code Smells in MatcherBase.java, MatcherException.java and MatchResult.java is Resolved

### DIFF
--- a/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/MatchResult.java
+++ b/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/MatchResult.java
@@ -29,7 +29,7 @@ public class MatchResult {
 	private MatchResult(boolean success, DependencyParsetree matchTree) {
 		this.matchTree = matchTree;
 		this.isSuccessfulMatch = success;
-		this.submatch = new HashMap<String, MatchResult>();
+		this.submatch = new HashMap<>();
 		this.ruleName = Optional.empty();
 	}
 	
@@ -68,8 +68,8 @@ public class MatchResult {
 	}
 
 	public static MatchResult success(DependencyParsetree matchTree) {
-		MatchResult result = new MatchResult(true, matchTree);
-		return result;
+		//MatchResult result = new MatchResult(true, matchTree);
+		return new MatchResult(true, matchTree);
 	}
 	
 	public static MatchResult success() {

--- a/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/MatcherException.java
+++ b/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/MatcherException.java
@@ -2,9 +2,7 @@ package com.specmate.cause_effect_patterns.parse.matcher;
 
 import java.util.Set;
 
-import com.specmate.cause_effect_patterns.parse.matcher.MatcherBase;
-import com.specmate.cause_effect_patterns.parse.matcher.MatcherException;
-import com.specmate.cause_effect_patterns.parse.matcher.SubtreeMatcher;
+
 
 public class MatcherException extends Exception {
 	
@@ -27,8 +25,10 @@ public class MatcherException extends Exception {
 
 	public static MatcherException multipleMatchheads(Set<MatcherBase> headSet) {
 		String message = "Rule has multiple match heads: ";
+		StringBuilder sb=new StringBuilder();
 		for(MatcherBase m: headSet) {
-			message += m+" "; 
+			message+=sb.append(m).append(" ").toString();
+			//message += m+" "; 
 		}
 		return new MatcherException(message);
 	}


### PR DESCRIPTION
**What's in the PR**

**Problem**

Replace the type specification in this constructor call with the diamond operator ("<>").
Merge this if statement with the enclosing one.
Remove this unnecessary import: same package classes are always implicitly imported.
Remove this unnecessary import: same package classes are always implicitly imported.
Remove this unnecessary import: same package classes are always implicitly imported.
Use a String Builder instead.
Remove this method and declare a constant for this value.
Replace the synchronized class "Vector" by an unsynchronized one such as "ArrayList" or "LinkedList".
Rename field "matching"
Remove this unnecessary import: same package classes are always implicitly imported.
Remove this unnecessary import: same package classes are always implicitly imported.
Remove this unnecessary import: same package classes are always implicitly imported.
Use a String Builder instead.
Replace the type specification in this constructor call with the diamond operator ("<>").
Immediately return this expression instead of assigning it to the temporary variable "result".

**Files:**

specmate-cause-effect-patterns/.../cause_effect_patterns/parse/matcher/MatcherBase.java

specmate-cause-effect-patterns/.../cause_effect_patterns/parse/matcher/MatcherException.java

specmate-cause-effect-patterns/.../cause_effect_patterns/parse/matcher/MatchResult.java

**Effort:** 5 Hours
