### PR TITLE
#39:[Codesmells]: CS in MatchRule.java, MatchUtil.java, OrMacther.java, SubtreeMacther.java, TokenMatcher.java and DependencyParsetree.java are resolved.

### DIFF
--- a/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/DependencyParsetree.java
+++ b/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/DependencyParsetree.java
@@ -97,9 +97,9 @@ public class DependencyParsetree {
 	}
 
 	public DependencyParsetree() {
-		dependencies = new HashMap<Token, DependencyNode>();
-		heads = new HashSet<Token>();
-		treeFragments = new Vector<DependencyParsetree.TextInterval>();
+		dependencies = new HashMap<>();
+		heads = new HashSet<>();
+		treeFragments = new Vector<>();
 		tokenOrder = new SortedIntSet();
 	}
 
@@ -206,11 +206,16 @@ public class DependencyParsetree {
 	@Override
 	public String toString() {
 		String result = "Roots:\n";
-		for(Token root: heads) {
-			result+= "\t"+root.getCoveredText()+"\n";
-		}
 
-		result+="Dependencies:\n";
+		StringBuilder sb_outer=new StringBuilder();
+		
+		for(Token root: heads) {
+			StringBuilder sb=new StringBuilder();
+			//result+= "\t"+root.getCoveredText()+"\n";
+			result+=sb.append("\t").append(root.getCoveredText()).append("\n").toString();
+		}
+		result+=sb_outer.append("Dependencies:\n");
+		//result+="Dependencies:\n";
 		for(Token t: dependencies.keySet()) {
 			result+= "\t"+t.getCoveredText()+"\n";
 			DependencyNode node = getDependencyNode(t);

--- a/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/MatchRule.java
+++ b/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/MatchRule.java
@@ -1,7 +1,7 @@
 package com.specmate.cause_effect_patterns.parse.matcher;
 
 import com.specmate.cause_effect_patterns.parse.DependencyParsetree;
-import com.specmate.cause_effect_patterns.parse.matcher.MatcherBase;
+
 
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 

--- a/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/MatchUtil.java
+++ b/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/MatchUtil.java
@@ -1,7 +1,8 @@
 package com.specmate.cause_effect_patterns.parse.matcher;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
+
 
 import com.specmate.cause_effect_patterns.parse.DependencyParsetree;
 
@@ -16,14 +17,17 @@ public class MatchUtil {
 	 * @return A List of Results for each head of the dependency data object.
 	 */
 	public static List<MatchResult> evaluateRuleset(List<MatchRule> rules, DependencyParsetree data) {
-		Vector<MatchResult> result = new Vector<MatchResult>();
+		List<MatchResult> result = new ArrayList<>();
 		for(Token head: data.getHeads()) {
 			result.add(MatchUtil.evaluateRuleset(rules, data, head));
 		}
 		return result; 
 	}
 	
-	
+	private MatchUtil()
+	{
+		
+	}
 	
 	
 	/**

--- a/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/OrMatcher.java
+++ b/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/OrMatcher.java
@@ -1,8 +1,7 @@
 package com.specmate.cause_effect_patterns.parse.matcher;
 
 import com.specmate.cause_effect_patterns.parse.DependencyParsetree;
-import com.specmate.cause_effect_patterns.parse.matcher.MatchResult;
-import com.specmate.cause_effect_patterns.parse.matcher.MatcherBase;
+
 
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 
@@ -23,13 +22,15 @@ public class OrMatcher extends MatcherBase{
 	@Override
 	public String getRepresentation() {
 		String result = "(";
+		StringBuilder sb_outer=new StringBuilder();
 		for (MatcherBase matcher : this.getArcChildren()) {
 			if(result.length() > 1) {
-				result+=" | ";
+				StringBuilder sb=new StringBuilder();
+				result+=sb.append(" | ").toString();
 			}
 			result+= matcher.toString();
 		}
-		return result+")";
+		return result+sb_outer.append(")").toString();
 	}
 	
 	@Override

--- a/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/SubtreeMatcher.java
+++ b/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/SubtreeMatcher.java
@@ -77,10 +77,8 @@ public class SubtreeMatcher extends MatcherBase {
 			}
 		}
 		
-		if(this.posTag.isPresent()) {
-			if(!head.getPosValue().equals(this.posTag.get())) {
+		if(this.posTag.isPresent() && !head.getPosValue().equals(this.posTag.get())) {
 				return MatchResult.unsuccessful();
-			}
 		}
 		
 		MatchResult res = super.match(data, head);

--- a/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/TokenMatcher.java
+++ b/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/matcher/TokenMatcher.java
@@ -3,8 +3,7 @@ package com.specmate.cause_effect_patterns.parse.matcher;
 import java.util.Optional;
 
 import com.specmate.cause_effect_patterns.parse.DependencyParsetree;
-import com.specmate.cause_effect_patterns.parse.matcher.MatchResult;
-import com.specmate.cause_effect_patterns.parse.matcher.MatcherBase;
+
 
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 
@@ -49,10 +48,8 @@ public class TokenMatcher extends MatcherBase{
 			return MatchResult.unsuccessful();
 		}
 		
-		if(this.posTag.isPresent()) {
-			if(!head.getPosValue().equals(this.posTag.get())) {
+		if(this.posTag.isPresent() && !head.getPosValue().equals(this.posTag.get())) {
 				return MatchResult.unsuccessful();
-			}
 		}
 		return super.match(data, head);
 	}


### PR DESCRIPTION
**What's in the PR**

**Problem**

Remove this unnecessary import: same package classes are always implicitly imported.
Replace the synchronized class "Vector" by an unsynchronized one such as "ArrayList" or "LinkedList".
Replace the type specification in this constructor call with the diamond operator ("<>").
Add a private constructor to hide the implicit public one.
Remove this unnecessary import: same package classes are always implicitly imported.
Remove this unnecessary import: same package classes are always implicitly imported.
Use a StringBuilder instead.
Use a StringBuilder instead.
Merge this if statement with the enclosing one.
Remove this unnecessary import: same package classes are always implicitly imported.
Remove this unnecessary import: same package classes are always implicitly imported.
Merge this if statement with the enclosing one.
Replace the type specification in this constructor call with the diamond operator ("<>").
Replace the type specification in this constructor call with the diamond operator ("<>").
Replace the type specification in this constructor call with the diamond operator ("<>").
Use a StringBuilder instead.
Use a StringBuilder instead.

**files**

specmate-cause-effect-patterns/.../cause_effect_patterns/parse/matcher/MatchRule.java
specmate-cause-effect-patterns/.../cause_effect_patterns/parse/matcher/OrMatcher.java
specmate-cause-effect-patterns/.../cause_effect_patterns/parse/matcher/SubtreeMatcher.java
specmate-cause-effect-patterns/.../cause_effect_patterns/parse/matcher/TokenMatcher.java
specmate-cause-effect-patterns/.../specmate/cause_effect_patterns/parse/DependencyParsetree.java

**Effort** : 5 Hours