### PR TITLE
#56:[CodeSmells]: cs in BinaryMatchResultTreeNode.java and MatchTreeBuilder.java is fixed.

### DIFF
--- a/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/wrapper/BinaryMatchResultTreeNode.java
+++ b/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/wrapper/BinaryMatchResultTreeNode.java
@@ -1,30 +1,30 @@
 package com.specmate.cause_effect_patterns.parse.wrapper;
 
 public class BinaryMatchResultTreeNode extends MatchResultTreeNode {
-	private MatchResultTreeNode left;
-	private MatchResultTreeNode right;
+	private MatchResultTreeNode left_var;
+	private MatchResultTreeNode right_var;
 	private RuleType type;
 	
 	public BinaryMatchResultTreeNode(MatchResultTreeNode left, MatchResultTreeNode right, RuleType type) {
-		this.left = left;
-		this.right = right;
+		this.left_var = left;
+		this.right_var = right;
 		this.type = type;
 	}
 	
 	public MatchResultTreeNode getFirstArgument() {
-		return this.left;
+		return this.left_var;
 	}
 	
 	public void setFirstArguement(MatchResultTreeNode node) {
-		this.left = node;
+		this.left_var = node;
 	}
 	
 	public MatchResultTreeNode getSecondArgument() {
-		return this.right;
+		return this.right_var;
 	}
 	
 	public void setSecondArguement(MatchResultTreeNode node) {
-		this.right = node;
+		this.right_var = node;
 	}
 	
 	protected void setType(RuleType type) {
@@ -43,10 +43,10 @@ public class BinaryMatchResultTreeNode extends MatchResultTreeNode {
 		this.type = left.getType();
 		left.setType(tmp);
 		
-		this.left  = childLeft;
-		this.right = left;
-		left.left  = childRight;
-		left.right = right;
+		this.left_var  = childLeft;
+		this.right_var = left;
+		left.left_var  = childRight;
+		left.right_var = right;
 	}
 
 	public void rightSwap() {
@@ -60,10 +60,10 @@ public class BinaryMatchResultTreeNode extends MatchResultTreeNode {
 		this.type = right.getType();
 		right.setType(tmp);
 		
-		this.left  = right;
-		this.right = childRight;
-		right.left  = left;
-		right.right = childLeft;
+		this.left_var  = right;
+		this.right_var = childRight;
+		right.left_var  = left;
+		right.right_var = childLeft;
 	}
 
 	@Override

--- a/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/wrapper/MatchTreeBuilder.java
+++ b/bundles/specmate-cause-effect-patterns/src/com/specmate/cause_effect_patterns/parse/wrapper/MatchTreeBuilder.java
@@ -13,7 +13,6 @@ public class MatchTreeBuilder {
 		public static final String EFFECT = "Effect";
 		public static final String PART_A = "PartA";
 		public static final String PART_B = "PartB";
-		// public static final String TMP = "TMP";
 		public static final String HEAD = "Head";
 		public static final String CONDITION = "Condition";
 		public static final String VARIABLE = "Variable";
@@ -123,7 +122,7 @@ public class MatchTreeBuilder {
 		if (name != null) {
 			return buildTree(result.getSubmatch(name));
 		}
-		return null;
+		return Optional.empty();
 	}
 
 	private String getSecondArgumentName(MatchResult result) {
@@ -148,7 +147,7 @@ public class MatchTreeBuilder {
 		if (name != null) {
 			return buildTree(result.getSubmatch(name));
 		}
-		return null;
+		return Optional.empty();
 	}
 
 	public RuleType getType(MatchResult result) {
@@ -184,17 +183,25 @@ public class MatchTreeBuilder {
 
 		// Unary
 		if (isNegation(result)) {
+			if(getFirstArgument(result).isPresent())
+			{
 			MatchResultTreeNode clause = getFirstArgument(result).get();
 			return Optional.of(new NegationTreeNode(clause));
+			}
 		}
 
 		// Binary
 		if (isConditionVarible(result) || isVerbObject(result) || isVerbPreposition(result) || isConjunction(result)
 				|| isCondition(result) || isLimitedCondition(result)) {
+			
+			if(getFirstArgument(result).isPresent() && getSecondArgument(result).isPresent())
+			{
+			
 			MatchResultTreeNode left = getFirstArgument(result).get();
 			MatchResultTreeNode right = getSecondArgument(result).get();
 			return Optional.of(new BinaryMatchResultTreeNode(left, right, getType(result)));
-		}
+			}
+			}
 
 		// Just Text
 		LeafTreeNode leaf = new LeafTreeNode(result.getMatchTree().getRepresentationString(false));


### PR DESCRIPTION
**What's in PR**
PROBLEMS:
Rename "left" which hides the field declared at line
Rename "right" which hides the field declared at line
Rename "left" which hides the field declared at line
Rename "right" which hides the field declared at line
Methods with an "Optional" return type should never return null
Methods with an "Optional" return type should never return null
Call "Optional#isPresent()" before accessing the value.
Call "Optional#isPresent()" before accessing the value
Call "Optional#isPresent()" before accessing the value.
1 duplicated blocks of code must be removed.
This block of commented-out lines of code should be removed

FILES:
specmate-cause-effect-patterns/.../ specmate/cause_effect_patterns/parse/wrappers/BinaryMatchResultTreeNode.Java

specmate-cause-effect-patterns/.../ specmate/cause_effect_patterns/parse/wrappers/MatchTreeBuilder.java

EFFORT: 4 1/2 hours