### PR TITLE
[issue #66] Feature - 7 : Icon for cause effect diagram.

### DIFF
--- a/web/src/app/modules/common/modules/icons/components/icon-selector.component.html
+++ b/web/src/app/modules/common/modules/icons/components/icon-selector.component.html
@@ -12,7 +12,7 @@
 </span>
 
 <span *ngIf="isCEGModel">
-    <i class="fa fa-share-alt" aria-hidden="true"></i>
+    <i class="fa fa-line-chart" aria-hidden="true"></i>
 </span>
 
 <span *ngIf="isManualTestSpecification">


### PR DESCRIPTION
I have changed to fa fa-line-chart icon from fa fa-share-alt. We have found this line graph favicon fits bets for cause effect graph.
@NIKHILESHMUPPANENI and @ajaykumaravula implemented this feature.


![Screenshot (3)](https://user-images.githubusercontent.com/61742906/97037936-531c1c80-156a-11eb-9e87-238dc337f384.png)
